### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: LIVE - Tag and Deploy
 
 on:
@@ -8,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Potential fix for [https://github.com/anyone-protocol/api-service/security/code-scanning/1](https://github.com/anyone-protocol/api-service/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only need to check out code and interact with Docker and deployment actions (which use secrets, not the token), the minimal permission required is likely `contents: read`. This should be added at the top level of the workflow (just below the `name:` line), so it applies to all jobs unless overridden. No changes to the jobs or steps are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
