### PR TITLE
Potential fix for code scanning alert no. 4: Server-side request forgery

### DIFF
--- a/src/OnionooService.ts
+++ b/src/OnionooService.ts
@@ -13,7 +13,7 @@ export class OnionooService {
     }
 
     async updateHardwareInfo(hardwareInfo: HardwareInfo): Promise<any> {
-        const finferprint = hardwareInfo.fingerprint;
+        const finferprint = encodeURIComponent(hardwareInfo.fingerprint);
         const response = await axios.put(`${this.baseUrl}/hardware/${finferprint}`, hardwareInfo).then();
         return response.data;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -219,7 +219,9 @@ const hardware_relay_validation_rules = [
     body('company').notEmpty().withMessage("company should not be empty"),
     body('format').notEmpty().withMessage("format should not be empty"),
     body('wallet').notEmpty().withMessage("wallet should not be empty"),
-    body('fingerprint').notEmpty().withMessage("fingerprint should not be empty"),
+    body('fingerprint')
+        .notEmpty().withMessage("fingerprint should not be empty")
+        .matches(/^[a-fA-F0-9]{40,64}$/).withMessage("fingerprint must be a 40-64 character hexadecimal string"),
     body('nftid').notEmpty().withMessage("nftid should not be empty"),
     body('build').notEmpty().withMessage("build should not be empty"),
     body('flags').notEmpty().withMessage("flags should not be empty"),


### PR DESCRIPTION
Potential fix for [https://github.com/anyone-protocol/api-service/security/code-scanning/4](https://github.com/anyone-protocol/api-service/security/code-scanning/4)

To fix this SSRF vulnerability, we need to ensure that the `fingerprint` value used in the URL path is strictly validated and sanitized. The best approach is to only allow fingerprints that match the expected format (e.g., a fixed-length hexadecimal string, if that's the case for your application). This can be enforced both at the API validation layer (in `src/app.ts`) and before constructing the URL in `src/OnionooService.ts`. Additionally, we should URL-encode the `fingerprint` value when interpolating it into the URL path to prevent path traversal or injection attacks.

**Steps:**
1. In `src/app.ts`, update the validation rules for the `fingerprint` field to require it to match a strict pattern (e.g., 40 or 64 lowercase hex characters).
2. In `src/OnionooService.ts`, URL-encode the `fingerprint` value before using it in the URL path.

No new methods or complex logic are needed, just a regex validation and a call to `encodeURIComponent`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
